### PR TITLE
Increased xdebug.max_nesting_level to 250

### DIFF
--- a/vagrant/manifests/default.pp
+++ b/vagrant/manifests/default.pp
@@ -140,6 +140,7 @@ augeas { "custom":
   changes => [
   "set PHP/date.timezone Europe/Vilnius",
   "set XDEBUG/xdebug.default_enable 1",
+  "set XDEBUG/xdebug.max_nesting_level 250",
   "set XDEBUG/xdebug.remote_autostart 0",
   "set XDEBUG/xdebug.remote_connect_back 1",
   "set XDEBUG/xdebug.remote_enable 1",


### PR DESCRIPTION
With default value sample tests ran with errors.
