### PR TITLE
Removal of port number solves "key 89DF5277 not found" error.

### DIFF
--- a/vagrant/manifests/default.pp
+++ b/vagrant/manifests/default.pp
@@ -17,7 +17,7 @@ apt::source { 'packages.dotdeb.org-php55':
     repos             => 'all',
     required_packages => 'debian-keyring debian-archive-keyring',
     key               => '89DF5277',
-    key_server        => 'hkp://keys.gnupg.net:80',
+    key_server        => 'hkp://keys.gnupg.net',
     include_src       => true
 }
 


### PR DESCRIPTION
Fixes #16 issue.