### PR TITLE
Add `--prefer-dist` to `composer install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ vagrant ssh
 Run project setup. There are bunch of commands to install vendors, assets and the demo data.
 
 ```bash
-composer install --no-interaction
+composer install --prefer-dist --no-interaction
 npm install
 bower install
 gulp


### PR DESCRIPTION
This will speed up the installation process.

> Composer will install from dist if possible. This can speed up installs substantially on build servers and other use cases where you typically do not run updates of the vendors. It is also a way to circumvent problems with git if you do not have a proper setup.

https://getcomposer.org/doc/03-cli.md#install